### PR TITLE
New feature to filter data using FetchXML queries.

### DIFF
--- a/MscrmTools.AttributeUsageInspector/FetchXMLDialog.Designer.cs
+++ b/MscrmTools.AttributeUsageInspector/FetchXMLDialog.Designer.cs
@@ -1,0 +1,206 @@
+﻿namespace MscrmTools.AttributeUsageInspector
+{
+    partial class FetchXMLDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.rTxtB_FetchXMLQuery = new System.Windows.Forms.RichTextBox();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.label5 = new System.Windows.Forms.Label();
+            this.cmb_userviews = new System.Windows.Forms.ComboBox();
+            this.label_userviews = new System.Windows.Forms.Label();
+            this.cmb_systemViews = new System.Windows.Forms.ComboBox();
+            this.label_systemviews = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.panel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // panel2
+            // 
+            this.panel2.BackColor = System.Drawing.SystemColors.Control;
+            this.panel2.Controls.Add(this.btnOK);
+            this.panel2.Controls.Add(this.btnCancel);
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panel2.Location = new System.Drawing.Point(0, 552);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(617, 60);
+            this.panel2.TabIndex = 2;
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOK.Location = new System.Drawing.Point(371, 11);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(5);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(113, 35);
+            this.btnOK.TabIndex = 5;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.Location = new System.Drawing.Point(491, 11);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(5);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(113, 35);
+            this.btnCancel.TabIndex = 4;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // rTxtB_FetchXMLQuery
+            // 
+            this.rTxtB_FetchXMLQuery.BackColor = System.Drawing.Color.White;
+            this.rTxtB_FetchXMLQuery.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rTxtB_FetchXMLQuery.Location = new System.Drawing.Point(10, 10);
+            this.rTxtB_FetchXMLQuery.Name = "rTxtB_FetchXMLQuery";
+            this.rTxtB_FetchXMLQuery.Size = new System.Drawing.Size(597, 348);
+            this.rTxtB_FetchXMLQuery.TabIndex = 3;
+            this.rTxtB_FetchXMLQuery.Text = "Loading views... Please wait";
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.label5);
+            this.splitContainer1.Panel1.Controls.Add(this.cmb_userviews);
+            this.splitContainer1.Panel1.Controls.Add(this.label_userviews);
+            this.splitContainer1.Panel1.Controls.Add(this.cmb_systemViews);
+            this.splitContainer1.Panel1.Controls.Add(this.label_systemviews);
+            this.splitContainer1.Panel1.Controls.Add(this.label1);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.rTxtB_FetchXMLQuery);
+            this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(10);
+            this.splitContainer1.Size = new System.Drawing.Size(617, 552);
+            this.splitContainer1.SplitterDistance = 180;
+            this.splitContainer1.TabIndex = 4;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(12, 56);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(316, 20);
+            this.label5.TabIndex = 7;
+            this.label5.Text = "Then click OK to continue or Cancel to stop.";
+            // 
+            // cmb_userviews
+            // 
+            this.cmb_userviews.FormattingEnabled = true;
+            this.cmb_userviews.Location = new System.Drawing.Point(134, 128);
+            this.cmb_userviews.Name = "cmb_userviews";
+            this.cmb_userviews.Size = new System.Drawing.Size(470, 28);
+            this.cmb_userviews.TabIndex = 6;
+            this.cmb_userviews.SelectedIndexChanged += new System.EventHandler(this.cmb_userviews_SelectedIndexChanged);
+            // 
+            // label_userviews
+            // 
+            this.label_userviews.AutoSize = true;
+            this.label_userviews.Location = new System.Drawing.Point(35, 136);
+            this.label_userviews.Name = "label_userviews";
+            this.label_userviews.Size = new System.Drawing.Size(93, 20);
+            this.label_userviews.TabIndex = 5;
+            this.label_userviews.Text = "User Views:";
+            // 
+            // cmb_systemViews
+            // 
+            this.cmb_systemViews.FormattingEnabled = true;
+            this.cmb_systemViews.Location = new System.Drawing.Point(134, 93);
+            this.cmb_systemViews.Name = "cmb_systemViews";
+            this.cmb_systemViews.Size = new System.Drawing.Size(470, 28);
+            this.cmb_systemViews.TabIndex = 4;
+            this.cmb_systemViews.SelectedIndexChanged += new System.EventHandler(this.cmb_systemViews_SelectedIndexChanged);
+            // 
+            // label_systemviews
+            // 
+            this.label_systemviews.AutoSize = true;
+            this.label_systemviews.Location = new System.Drawing.Point(16, 98);
+            this.label_systemviews.Name = "label_systemviews";
+            this.label_systemviews.Size = new System.Drawing.Size(112, 20);
+            this.label_systemviews.TabIndex = 2;
+            this.label_systemviews.Text = "System Views:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 20);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(450, 20);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Choose a view or just paste your FetchXML query in this editor.";
+            // 
+            // FetchXMLDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(617, 612);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.panel2);
+            this.Name = "FetchXMLDialog";
+            this.ShowIcon = false;
+            this.Text = "FetchXML Query";
+            this.panel2.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.RichTextBox rTxtB_FetchXMLQuery;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label_systemviews;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.ComboBox cmb_userviews;
+        private System.Windows.Forms.Label label_userviews;
+        private System.Windows.Forms.ComboBox cmb_systemViews;
+    }
+}

--- a/MscrmTools.AttributeUsageInspector/FetchXMLDialog.Designer.cs
+++ b/MscrmTools.AttributeUsageInspector/FetchXMLDialog.Designer.cs
@@ -39,6 +39,7 @@
             this.cmb_systemViews = new System.Windows.Forms.ComboBox();
             this.label_systemviews = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
+            this.txb_validationResult = new System.Windows.Forms.TextBox();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -49,18 +50,20 @@
             // panel2
             // 
             this.panel2.BackColor = System.Drawing.SystemColors.Control;
+            this.panel2.Controls.Add(this.txb_validationResult);
             this.panel2.Controls.Add(this.btnOK);
             this.panel2.Controls.Add(this.btnCancel);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel2.Location = new System.Drawing.Point(0, 552);
+            this.panel2.Location = new System.Drawing.Point(0, 569);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(617, 60);
+            this.panel2.Size = new System.Drawing.Size(617, 69);
             this.panel2.TabIndex = 2;
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.Location = new System.Drawing.Point(371, 11);
+            this.btnOK.Enabled = false;
+            this.btnOK.Location = new System.Drawing.Point(371, 20);
             this.btnOK.Margin = new System.Windows.Forms.Padding(5);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(113, 35);
@@ -72,7 +75,7 @@
             // btnCancel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCancel.Location = new System.Drawing.Point(491, 11);
+            this.btnCancel.Location = new System.Drawing.Point(491, 20);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(113, 35);
@@ -87,9 +90,10 @@
             this.rTxtB_FetchXMLQuery.Dock = System.Windows.Forms.DockStyle.Fill;
             this.rTxtB_FetchXMLQuery.Location = new System.Drawing.Point(10, 10);
             this.rTxtB_FetchXMLQuery.Name = "rTxtB_FetchXMLQuery";
-            this.rTxtB_FetchXMLQuery.Size = new System.Drawing.Size(597, 348);
+            this.rTxtB_FetchXMLQuery.Size = new System.Drawing.Size(597, 360);
             this.rTxtB_FetchXMLQuery.TabIndex = 3;
             this.rTxtB_FetchXMLQuery.Text = "Loading views... Please wait";
+            this.rTxtB_FetchXMLQuery.TextChanged += new System.EventHandler(this.rTxtB_FetchXMLQuery_TextChanged);
             // 
             // splitContainer1
             // 
@@ -111,8 +115,8 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.rTxtB_FetchXMLQuery);
             this.splitContainer1.Panel2.Padding = new System.Windows.Forms.Padding(10);
-            this.splitContainer1.Size = new System.Drawing.Size(617, 552);
-            this.splitContainer1.SplitterDistance = 180;
+            this.splitContainer1.Size = new System.Drawing.Size(617, 569);
+            this.splitContainer1.SplitterDistance = 185;
             this.splitContainer1.TabIndex = 4;
             // 
             // label5
@@ -169,17 +173,30 @@
             this.label1.TabIndex = 0;
             this.label1.Text = "Choose a view or just paste your FetchXML query in this editor.";
             // 
+            // txb_validationResult
+            // 
+            this.txb_validationResult.BackColor = System.Drawing.SystemColors.Control;
+            this.txb_validationResult.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txb_validationResult.Location = new System.Drawing.Point(10, 20);
+            this.txb_validationResult.Multiline = true;
+            this.txb_validationResult.Name = "txb_validationResult";
+            this.txb_validationResult.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.txb_validationResult.Size = new System.Drawing.Size(347, 35);
+            this.txb_validationResult.TabIndex = 6;
+            this.txb_validationResult.Text = "Validating FetchXML query ...";
+            // 
             // FetchXMLDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(617, 612);
+            this.ClientSize = new System.Drawing.Size(617, 638);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.panel2);
             this.Name = "FetchXMLDialog";
             this.ShowIcon = false;
             this.Text = "FetchXML Query";
             this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
@@ -202,5 +219,6 @@
         private System.Windows.Forms.ComboBox cmb_userviews;
         private System.Windows.Forms.Label label_userviews;
         private System.Windows.Forms.ComboBox cmb_systemViews;
+        private System.Windows.Forms.TextBox txb_validationResult;
     }
 }

--- a/MscrmTools.AttributeUsageInspector/FetchXMLDialog.cs
+++ b/MscrmTools.AttributeUsageInspector/FetchXMLDialog.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace MscrmTools.AttributeUsageInspector
+{
+    public partial class FetchXMLDialog : Form
+    {
+        public string FetchXMLQuery { get; private set; }
+
+        private IOrganizationService _service;
+
+        public FetchXMLDialog()
+        {
+            InitializeComponent();
+        }
+
+        public FetchXMLDialog(IOrganizationService service, Settings settings, EntityMetadata selectedEntity, EntityMetadataCollection entities)
+            : this()
+        {
+            this._service = service;
+
+            Task.Run(() => LoadSystemViews(selectedEntity));
+            Task.Run(() => LoadUserViews(selectedEntity));
+        }
+
+        private void LoadUserViews(EntityMetadata selectedEntity)
+        {
+            QueryExpression query = new QueryExpression("userquery");
+            query.ColumnSet.AddColumns(new string[] { "name", "fetchxml" });
+            query.Criteria.AddCondition("returnedtypecode", ConditionOperator.Equal, selectedEntity.LogicalName);
+
+            EntityCollection savedQueryCollection = _service.RetrieveMultiple(query);
+            if (savedQueryCollection.Entities != null && savedQueryCollection.Entities.Count > 0)
+            {
+                IOrderedEnumerable<Entity> views = savedQueryCollection.Entities.OrderBy(v => v["name"] as string);
+                foreach (Entity view in views)
+                {
+                    cmb_userviews.Items.Add(new DropDownViewItem(view["name"] as string, view["fetchxml"] as string));
+                }
+            }
+        }
+
+        private void LoadSystemViews(EntityMetadata selectedEntity)
+        {
+            QueryExpression query = new QueryExpression("savedquery");
+            query.ColumnSet.AddColumns(new string[] { "name", "fetchxml" });
+            query.Criteria.AddCondition("returnedtypecode", ConditionOperator.Equal, selectedEntity.LogicalName);
+
+            EntityCollection savedQueryCollection = _service.RetrieveMultiple(query);
+            if (savedQueryCollection.Entities!=null && savedQueryCollection.Entities.Count > 0)
+            {
+                IOrderedEnumerable<Entity> views = savedQueryCollection.Entities.OrderBy(v => v["name"] as string);
+                foreach (Entity view in views)
+                {
+                    cmb_systemViews.Items.Add(new DropDownViewItem(view["name"] as string, view["fetchxml"] as string));
+                }
+                DropDownViewItem selectedView = cmb_systemViews.Items[0] as DropDownViewItem;
+                cmb_systemViews.SelectedItem = selectedView;
+                this.rTxtB_FetchXMLQuery.Text = selectedView.FetchXML;
+            }
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            FetchXMLQuery = this.rTxtB_FetchXMLQuery.Text;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void cmb_systemViews_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            DropDownViewItem selectedView = this.cmb_systemViews.SelectedItem as DropDownViewItem;
+            if (selectedView != null)
+            {
+                cmb_systemViews.SelectedItem = selectedView;
+                this.rTxtB_FetchXMLQuery.Text = selectedView.FetchXML;
+            }
+        }
+
+        private void cmb_userviews_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            DropDownViewItem selectedView = this.cmb_userviews.SelectedItem as DropDownViewItem;
+            if (selectedView != null)
+            {
+                cmb_userviews.SelectedItem = selectedView;
+                this.rTxtB_FetchXMLQuery.Text = selectedView.FetchXML;
+            }
+        }
+    }
+
+    internal class DropDownViewItem
+    {
+        internal string ViewName { get; private set; }
+
+        internal string FetchXML { get; private set; }
+
+        internal DropDownViewItem(string viewName, string fetchXML)
+        {
+            this.ViewName = viewName;
+            this.FetchXML = fetchXML;
+        }
+
+        public override string ToString()
+        {
+            return this.ViewName;
+        }
+    }
+}

--- a/MscrmTools.AttributeUsageInspector/FetchXMLDialog.cs
+++ b/MscrmTools.AttributeUsageInspector/FetchXMLDialog.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xrm.Sdk;
+﻿using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using System;
@@ -7,6 +8,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using System.ServiceModel;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -19,6 +21,8 @@ namespace MscrmTools.AttributeUsageInspector
 
         private IOrganizationService _service;
 
+        private EntityMetadata _selectedEntity;
+
         public FetchXMLDialog()
         {
             InitializeComponent();
@@ -28,6 +32,7 @@ namespace MscrmTools.AttributeUsageInspector
             : this()
         {
             this._service = service;
+            this._selectedEntity = selectedEntity;
 
             Task.Run(() => LoadSystemViews(selectedEntity));
             Task.Run(() => LoadUserViews(selectedEntity));
@@ -100,6 +105,68 @@ namespace MscrmTools.AttributeUsageInspector
                 cmb_userviews.SelectedItem = selectedView;
                 this.rTxtB_FetchXMLQuery.Text = selectedView.FetchXML;
             }
+        }
+
+        private async void rTxtB_FetchXMLQuery_TextChanged(object sender, EventArgs e)
+        {
+            txb_validationResult.ForeColor = Color.Black; 
+            txb_validationResult.Text = "Validating FetchXML query...";
+
+            string fetchXMLQuery = this.rTxtB_FetchXMLQuery.Text;
+            if (string.IsNullOrEmpty(fetchXMLQuery))
+                ShowInvalidQueryResults("Invalid query. FetchXML query cannot empty");
+            else
+            {
+                try
+                {
+                    var queryExpression = await Task.Run(() => ConvertFetchXMLtoQuery(fetchXMLQuery));
+                    if (queryExpression.EntityName != this._selectedEntity.LogicalName)
+                    {
+                        ShowInvalidQueryResults("Invalid query. The selected entity doesn't match the entity in the FetchXML query");
+                    }
+                    else if (queryExpression.ColumnSet.AllColumns == true)
+                        ShowInvalidQueryResults("Invalid query. All columns shouldn't be selected, choose just the ones you need");
+                    else
+                        ShowValidQueryResults("FetchXML is correct");
+                }
+                catch(FaultException<Microsoft.Xrm.Sdk.OrganizationServiceFault> exc)
+                {
+                    ShowInvalidQueryResults(string.Format("{0}. {1}", exc.Message, exc.Detail));
+                }
+                catch (Exception exc)
+                {
+                    ShowInvalidQueryResults(exc.Message);
+                }
+            }
+        }
+
+        private void ShowInvalidQueryResults(string message)
+        {
+            txb_validationResult.Text = message;
+            txb_validationResult.ForeColor = Color.Red;
+            btnOK.Enabled = false;
+        }
+
+        private void ShowValidQueryResults(string message)
+        {
+            txb_validationResult.Text = message;
+            txb_validationResult.ForeColor = Color.Green;
+            btnOK.Enabled = true;
+        }
+
+        private QueryExpression ConvertFetchXMLtoQuery(string fetchXMLQuery)
+        {
+            FetchXmlToQueryExpressionRequest conversionRequest = new FetchXmlToQueryExpressionRequest
+            {
+                FetchXml = fetchXMLQuery
+            };
+
+            FetchXmlToQueryExpressionResponse conversionResponse =
+                (FetchXmlToQueryExpressionResponse)_service.Execute(conversionRequest);
+
+            QueryExpression queryExpression = conversionResponse.Query;
+
+            return queryExpression;
         }
     }
 

--- a/MscrmTools.AttributeUsageInspector/FetchXMLDialog.resx
+++ b/MscrmTools.AttributeUsageInspector/FetchXMLDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/MscrmTools.AttributeUsageInspector/FilterAttributesDialog.Designer.cs
+++ b/MscrmTools.AttributeUsageInspector/FilterAttributesDialog.Designer.cs
@@ -61,19 +61,19 @@
             this.panel2.Controls.Add(this.btnOK);
             this.panel2.Controls.Add(this.btnCancel);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel2.Location = new System.Drawing.Point(0, 353);
-            this.panel2.Margin = new System.Windows.Forms.Padding(2);
+            this.panel2.Location = new System.Drawing.Point(0, 543);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(454, 39);
+            this.panel2.Size = new System.Drawing.Size(681, 60);
             this.panel2.TabIndex = 3;
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(290, 7);
+            this.btnOK.Location = new System.Drawing.Point(435, 11);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.Size = new System.Drawing.Size(112, 35);
             this.btnOK.TabIndex = 5;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -83,9 +83,10 @@
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(370, 7);
+            this.btnCancel.Location = new System.Drawing.Point(555, 11);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(112, 35);
             this.btnCancel.TabIndex = 4;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -97,19 +98,17 @@
             this.panel1.Controls.Add(this.lblHeader);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(2);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(454, 39);
+            this.panel1.Size = new System.Drawing.Size(681, 60);
             this.panel1.TabIndex = 2;
             // 
             // lblHeader
             // 
             this.lblHeader.AutoSize = true;
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Light", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeader.Location = new System.Drawing.Point(2, 6);
-            this.lblHeader.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblHeader.Location = new System.Drawing.Point(3, 9);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(131, 25);
+            this.lblHeader.Size = new System.Drawing.Size(190, 38);
             this.lblHeader.TabIndex = 0;
             this.lblHeader.Text = "Filter attributes";
             // 
@@ -117,9 +116,10 @@
             // 
             this.rbAll.AutoSize = true;
             this.rbAll.Checked = true;
-            this.rbAll.Location = new System.Drawing.Point(3, 5);
+            this.rbAll.Location = new System.Drawing.Point(4, 8);
+            this.rbAll.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbAll.Name = "rbAll";
-            this.rbAll.Size = new System.Drawing.Size(36, 17);
+            this.rbAll.Size = new System.Drawing.Size(51, 24);
             this.rbAll.TabIndex = 4;
             this.rbAll.TabStop = true;
             this.rbAll.Text = "All";
@@ -128,9 +128,10 @@
             // rbCustom
             // 
             this.rbCustom.AutoSize = true;
-            this.rbCustom.Location = new System.Drawing.Point(3, 28);
+            this.rbCustom.Location = new System.Drawing.Point(4, 43);
+            this.rbCustom.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbCustom.Name = "rbCustom";
-            this.rbCustom.Size = new System.Drawing.Size(129, 17);
+            this.rbCustom.Size = new System.Drawing.Size(192, 24);
             this.rbCustom.TabIndex = 5;
             this.rbCustom.Text = "Only custom attributes";
             this.rbCustom.UseVisualStyleBackColor = true;
@@ -138,9 +139,10 @@
             // rbStandard
             // 
             this.rbStandard.AutoSize = true;
-            this.rbStandard.Location = new System.Drawing.Point(3, 51);
+            this.rbStandard.Location = new System.Drawing.Point(4, 78);
+            this.rbStandard.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbStandard.Name = "rbStandard";
-            this.rbStandard.Size = new System.Drawing.Size(136, 17);
+            this.rbStandard.Size = new System.Drawing.Size(203, 24);
             this.rbStandard.TabIndex = 6;
             this.rbStandard.Text = "Only standard attributes";
             this.rbStandard.UseVisualStyleBackColor = true;
@@ -148,9 +150,10 @@
             // rbChoose
             // 
             this.rbChoose.AutoSize = true;
-            this.rbChoose.Location = new System.Drawing.Point(3, 74);
+            this.rbChoose.Location = new System.Drawing.Point(4, 114);
+            this.rbChoose.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.rbChoose.Name = "rbChoose";
-            this.rbChoose.Size = new System.Drawing.Size(95, 17);
+            this.rbChoose.Size = new System.Drawing.Size(139, 24);
             this.rbChoose.TabIndex = 7;
             this.rbChoose.Text = "Let me choose";
             this.rbChoose.UseVisualStyleBackColor = true;
@@ -163,9 +166,10 @@
             this.panel3.Controls.Add(this.rbChoose);
             this.panel3.Controls.Add(this.rbStandard);
             this.panel3.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel3.Location = new System.Drawing.Point(0, 39);
+            this.panel3.Location = new System.Drawing.Point(0, 60);
+            this.panel3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(454, 100);
+            this.panel3.Size = new System.Drawing.Size(681, 154);
             this.panel3.TabIndex = 9;
             // 
             // gbAttributesSelection
@@ -174,9 +178,11 @@
             this.gbAttributesSelection.Controls.Add(this.panel4);
             this.gbAttributesSelection.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbAttributesSelection.Enabled = false;
-            this.gbAttributesSelection.Location = new System.Drawing.Point(0, 139);
+            this.gbAttributesSelection.Location = new System.Drawing.Point(0, 214);
+            this.gbAttributesSelection.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.gbAttributesSelection.Name = "gbAttributesSelection";
-            this.gbAttributesSelection.Size = new System.Drawing.Size(454, 214);
+            this.gbAttributesSelection.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.gbAttributesSelection.Size = new System.Drawing.Size(681, 329);
             this.gbAttributesSelection.TabIndex = 10;
             this.gbAttributesSelection.TabStop = false;
             this.gbAttributesSelection.Text = "Select attributes to audit";
@@ -188,9 +194,10 @@
             this.chDisplayName,
             this.chLogicalName});
             this.lvAttributes.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lvAttributes.Location = new System.Drawing.Point(3, 34);
+            this.lvAttributes.Location = new System.Drawing.Point(4, 52);
+            this.lvAttributes.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.lvAttributes.Name = "lvAttributes";
-            this.lvAttributes.Size = new System.Drawing.Size(448, 177);
+            this.lvAttributes.Size = new System.Drawing.Size(673, 272);
             this.lvAttributes.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvAttributes.TabIndex = 2;
             this.lvAttributes.UseCompatibleStateImageBehavior = false;
@@ -215,18 +222,20 @@
             this.panel4.Controls.Add(this.llNone);
             this.panel4.Controls.Add(this.llSelectAll);
             this.panel4.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel4.Location = new System.Drawing.Point(3, 16);
+            this.panel4.Location = new System.Drawing.Point(4, 24);
+            this.panel4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(448, 18);
+            this.panel4.Size = new System.Drawing.Size(673, 28);
             this.panel4.TabIndex = 1;
             // 
             // llInvertSelection
             // 
             this.llInvertSelection.AutoSize = true;
             this.llInvertSelection.Dock = System.Windows.Forms.DockStyle.Right;
-            this.llInvertSelection.Location = new System.Drawing.Point(100, 0);
+            this.llInvertSelection.Location = new System.Drawing.Point(159, 0);
+            this.llInvertSelection.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.llInvertSelection.Name = "llInvertSelection";
-            this.llInvertSelection.Size = new System.Drawing.Size(79, 13);
+            this.llInvertSelection.Size = new System.Drawing.Size(116, 20);
             this.llInvertSelection.TabIndex = 5;
             this.llInvertSelection.TabStop = true;
             this.llInvertSelection.Text = "Invert selection";
@@ -236,9 +245,10 @@
             // 
             this.llStandard.AutoSize = true;
             this.llStandard.Dock = System.Windows.Forms.DockStyle.Right;
-            this.llStandard.Location = new System.Drawing.Point(179, 0);
+            this.llStandard.Location = new System.Drawing.Point(275, 0);
+            this.llStandard.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.llStandard.Name = "llStandard";
-            this.llStandard.Size = new System.Drawing.Size(81, 13);
+            this.llStandard.Size = new System.Drawing.Size(121, 20);
             this.llStandard.TabIndex = 4;
             this.llStandard.TabStop = true;
             this.llStandard.Text = "Select standard";
@@ -248,9 +258,10 @@
             // 
             this.llCustom.AutoSize = true;
             this.llCustom.Dock = System.Windows.Forms.DockStyle.Right;
-            this.llCustom.Location = new System.Drawing.Point(260, 0);
+            this.llCustom.Location = new System.Drawing.Point(396, 0);
+            this.llCustom.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.llCustom.Name = "llCustom";
-            this.llCustom.Size = new System.Drawing.Size(74, 13);
+            this.llCustom.Size = new System.Drawing.Size(110, 20);
             this.llCustom.TabIndex = 3;
             this.llCustom.TabStop = true;
             this.llCustom.Text = "Select custom";
@@ -260,9 +271,10 @@
             // 
             this.llNone.AutoSize = true;
             this.llNone.Dock = System.Windows.Forms.DockStyle.Right;
-            this.llNone.Location = new System.Drawing.Point(334, 0);
+            this.llNone.Location = new System.Drawing.Point(506, 0);
+            this.llNone.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.llNone.Name = "llNone";
-            this.llNone.Size = new System.Drawing.Size(64, 13);
+            this.llNone.Size = new System.Drawing.Size(94, 20);
             this.llNone.TabIndex = 1;
             this.llNone.TabStop = true;
             this.llNone.Text = "Select none";
@@ -272,9 +284,10 @@
             // 
             this.llSelectAll.AutoSize = true;
             this.llSelectAll.Dock = System.Windows.Forms.DockStyle.Right;
-            this.llSelectAll.Location = new System.Drawing.Point(398, 0);
+            this.llSelectAll.Location = new System.Drawing.Point(600, 0);
+            this.llSelectAll.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.llSelectAll.Name = "llSelectAll";
-            this.llSelectAll.Size = new System.Drawing.Size(50, 13);
+            this.llSelectAll.Size = new System.Drawing.Size(73, 20);
             this.llSelectAll.TabIndex = 0;
             this.llSelectAll.TabStop = true;
             this.llSelectAll.Text = "Select all";
@@ -282,13 +295,14 @@
             // 
             // FilterAttributesDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(454, 392);
+            this.ClientSize = new System.Drawing.Size(681, 603);
             this.Controls.Add(this.gbAttributesSelection);
             this.Controls.Add(this.panel3);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "FilterAttributesDialog";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/MscrmTools.AttributeUsageInspector/MetadataHelper.cs
+++ b/MscrmTools.AttributeUsageInspector/MetadataHelper.cs
@@ -99,5 +99,10 @@ namespace MscrmTools.AttributeUsageInspector
                             && a.LogicalName.IndexOf("composite") < 0
                             ).OrderBy(a => a.LogicalName);
         }
+
+        public static AttributeMetadata GetMetadataAttribute (AttributeMetadata[] attributes, string attributeName)
+        {
+            return attributes.Where(a => a.LogicalName == attributeName).FirstOrDefault();
+        }
     }
 }

--- a/MscrmTools.AttributeUsageInspector/MscrmTools.AttributeUsageInspector.csproj
+++ b/MscrmTools.AttributeUsageInspector/MscrmTools.AttributeUsageInspector.csproj
@@ -31,18 +31,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EPPlus, Version=4.1.0.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
-      <HintPath>..\packages\EPPlus.4.1.0\lib\net40\EPPlus.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EPPlus, Version=4.5.2.1, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
+      <HintPath>..\packages\EPPlus.4.5.2.1\lib\net40\EPPlus.dll</HintPath>
     </Reference>
-    <Reference Include="McTools.Xrm.Connection, Version=1.2017.10.15, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
-      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2017.10.15\lib\net462\McTools.Xrm.Connection.dll</HintPath>
+    <Reference Include="McTools.Xrm.Connection, Version=1.2018.7.19, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
+      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2018.7.19\lib\net462\McTools.Xrm.Connection.dll</HintPath>
     </Reference>
-    <Reference Include="McTools.Xrm.Connection.WinForms, Version=1.2017.10.15, Culture=neutral, PublicKeyToken=f1559f79cf894e27, processorArchitecture=MSIL">
-      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2017.10.15\lib\net462\McTools.Xrm.Connection.WinForms.dll</HintPath>
+    <Reference Include="McTools.Xrm.Connection.WinForms, Version=1.2018.7.19, Culture=neutral, PublicKeyToken=f1559f79cf894e27, processorArchitecture=MSIL">
+      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2018.7.19\lib\net462\McTools.Xrm.Connection.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.5\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.3\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -54,31 +53,37 @@
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.3\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.2\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.5\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.3\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.0.5\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.3\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.0.5\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.3\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.0.5\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.3\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
@@ -100,14 +105,20 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="XrmToolBox, Version=1.2017.10.19, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.10.19\lib\net462\XrmToolBox.exe</HintPath>
+    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.4.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.3.0.4\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
     </Reference>
-    <Reference Include="XrmToolBox.Extensibility, Version=1.2017.7.10, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.10.19\lib\net462\XrmToolBox.Extensibility.dll</HintPath>
+    <Reference Include="WeifenLuo.WinFormsUI.Docking.ThemeVS2015, Version=3.0.4.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.ThemeVS2015.3.0.4\lib\net40\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll</HintPath>
     </Reference>
-    <Reference Include="XrmToolBox.PluginsStore, Version=1.2017.10.7, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.10.19\lib\net462\XrmToolBox.PluginsStore.dll</HintPath>
+    <Reference Include="XrmToolBox, Version=1.2018.7.28, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2018.7.28\lib\net462\XrmToolBox.exe</HintPath>
+    </Reference>
+    <Reference Include="XrmToolBox.Extensibility, Version=1.2018.7.28, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2018.7.28\lib\net462\XrmToolBox.Extensibility.dll</HintPath>
+    </Reference>
+    <Reference Include="XrmToolBox.PluginsStore, Version=1.2018.7.28, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2018.7.28\lib\net462\XrmToolBox.PluginsStore.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -117,6 +128,12 @@
     <Compile Include="DetectiveEngine.cs" />
     <Compile Include="EntityFilterSetting.cs" />
     <Compile Include="ExcelEngine.cs" />
+    <Compile Include="FetchXMLDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FetchXMLDialog.Designer.cs">
+      <DependentUpon>FetchXMLDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="FilterAttributesDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -151,6 +168,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="FetchXMLDialog.resx">
+      <DependentUpon>FetchXMLDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="FilterAttributesDialog.resx">
       <DependentUpon>FilterAttributesDialog.cs</DependentUpon>
     </EmbeddedResource>
@@ -171,7 +191,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>IF NOT EXIST merged mkdir merged
-"$(SolutionDir)packages\ILMerge.2.14.1208\tools\ILMerge.exe" /targetplatform:v4,"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2" /lib:"C:\Windows\Microsoft.Net\Framework64\v4.0.30319" /out:"$(TargetDir)Merged\$(TargetFileName)" $(TargetFileName)  $(TargetDir)EPPlus.dll</PostBuildEvent>
+"$(SolutionDir)packages\ILMerge.2.14.1208\tools\ILMerge.exe" /targetplatform:v4,"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2" /lib:"C:\Windows\Microsoft.Net\Framework64\v4.0.30319" /out:"$(TargetDir)Merged\$(TargetFileName)" $(TargetFileName)  $(TargetDir)EPPlus.dll
+if $(ConfigurationName) == Debug (
+  IF NOT EXIST Plugins mkdir Plugins
+  move /Y "$(TargetDir)Merged\$(TargetFileName)" Plugins
+)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MscrmTools.AttributeUsageInspector/PluginControl.Designer.cs
+++ b/MscrmTools.AttributeUsageInspector/PluginControl.Designer.cs
@@ -87,6 +87,7 @@ namespace MscrmTools.AttributeUsageInspector
             // 
             // tsMain
             // 
+            this.tsMain.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.tsMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbClose,
             this.toolStripSeparator1,
@@ -99,7 +100,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.tsbCancel});
             this.tsMain.Location = new System.Drawing.Point(0, 0);
             this.tsMain.Name = "tsMain";
-            this.tsMain.Size = new System.Drawing.Size(1631, 37);
+            this.tsMain.Size = new System.Drawing.Size(1631, 32);
             this.tsMain.TabIndex = 0;
             this.tsMain.Text = "tsMain";
             // 
@@ -109,35 +110,35 @@ namespace MscrmTools.AttributeUsageInspector
             this.tsbClose.Image = ((System.Drawing.Image)(resources.GetObject("tsbClose.Image")));
             this.tsbClose.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbClose.Name = "tsbClose";
-            this.tsbClose.Size = new System.Drawing.Size(32, 34);
+            this.tsbClose.Size = new System.Drawing.Size(28, 29);
             this.tsbClose.Text = "Close";
             this.tsbClose.Click += new System.EventHandler(this.tsbClose_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 37);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 32);
             // 
             // tsbLoadEntities
             // 
             this.tsbLoadEntities.Image = ((System.Drawing.Image)(resources.GetObject("tsbLoadEntities.Image")));
             this.tsbLoadEntities.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbLoadEntities.Name = "tsbLoadEntities";
-            this.tsbLoadEntities.Size = new System.Drawing.Size(163, 34);
+            this.tsbLoadEntities.Size = new System.Drawing.Size(140, 29);
             this.tsbLoadEntities.Text = "Load Entities";
             this.tsbLoadEntities.Click += new System.EventHandler(this.tsbLoadEntities_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 37);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 32);
             // 
             // tsbExportToExcel
             // 
             this.tsbExportToExcel.Image = ((System.Drawing.Image)(resources.GetObject("tsbExportToExcel.Image")));
             this.tsbExportToExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbExportToExcel.Name = "tsbExportToExcel";
-            this.tsbExportToExcel.Size = new System.Drawing.Size(184, 34);
+            this.tsbExportToExcel.Size = new System.Drawing.Size(157, 29);
             this.tsbExportToExcel.Text = "Export To Excel";
             this.tsbExportToExcel.ToolTipText = "Export checked entities data usage to Excel Spreadsheet";
             this.tsbExportToExcel.Click += new System.EventHandler(this.tsbExportToExcel_Click);
@@ -145,7 +146,7 @@ namespace MscrmTools.AttributeUsageInspector
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 37);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(6, 32);
             // 
             // tsbSettings
             // 
@@ -153,7 +154,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.tsbSettings.Image = ((System.Drawing.Image)(resources.GetObject("tsbSettings.Image")));
             this.tsbSettings.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbSettings.Name = "tsbSettings";
-            this.tsbSettings.Size = new System.Drawing.Size(32, 34);
+            this.tsbSettings.Size = new System.Drawing.Size(28, 29);
             this.tsbSettings.Text = "Settings";
             this.tsbSettings.ToolTipText = "Define number of records returned per call";
             this.tsbSettings.Click += new System.EventHandler(this.tsbSettings_Click);
@@ -161,7 +162,7 @@ namespace MscrmTools.AttributeUsageInspector
             // tssCancel
             // 
             this.tssCancel.Name = "tssCancel";
-            this.tssCancel.Size = new System.Drawing.Size(6, 37);
+            this.tssCancel.Size = new System.Drawing.Size(6, 32);
             this.tssCancel.Visible = false;
             // 
             // tsbCancel
@@ -169,7 +170,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.tsbCancel.Image = global::MscrmTools.AttributeUsageInspector.Properties.Resources.cancel;
             this.tsbCancel.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbCancel.Name = "tsbCancel";
-            this.tsbCancel.Size = new System.Drawing.Size(107, 34);
+            this.tsbCancel.Size = new System.Drawing.Size(91, 29);
             this.tsbCancel.Text = "Cancel";
             this.tsbCancel.ToolTipText = "Clicking on this button will stop data loading and perform analysis on records re" +
     "trieved so far";
@@ -179,7 +180,7 @@ namespace MscrmTools.AttributeUsageInspector
             // scInspector
             // 
             this.scInspector.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.scInspector.Location = new System.Drawing.Point(0, 37);
+            this.scInspector.Location = new System.Drawing.Point(0, 32);
             this.scInspector.Name = "scInspector";
             // 
             // scInspector.Panel1
@@ -189,7 +190,7 @@ namespace MscrmTools.AttributeUsageInspector
             // scInspector.Panel2
             // 
             this.scInspector.Panel2.Controls.Add(this.gbData);
-            this.scInspector.Size = new System.Drawing.Size(1631, 929);
+            this.scInspector.Size = new System.Drawing.Size(1631, 934);
             this.scInspector.SplitterDistance = 543;
             this.scInspector.TabIndex = 1;
             // 
@@ -200,7 +201,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.gbEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbEntities.Location = new System.Drawing.Point(0, 0);
             this.gbEntities.Name = "gbEntities";
-            this.gbEntities.Size = new System.Drawing.Size(543, 929);
+            this.gbEntities.Size = new System.Drawing.Size(543, 934);
             this.gbEntities.TabIndex = 0;
             this.gbEntities.TabStop = false;
             this.gbEntities.Text = "Entities";
@@ -214,9 +215,9 @@ namespace MscrmTools.AttributeUsageInspector
             this.lvEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvEntities.FullRowSelect = true;
             this.lvEntities.HideSelection = false;
-            this.lvEntities.Location = new System.Drawing.Point(3, 51);
+            this.lvEntities.Location = new System.Drawing.Point(3, 48);
             this.lvEntities.Name = "lvEntities";
-            this.lvEntities.Size = new System.Drawing.Size(537, 875);
+            this.lvEntities.Size = new System.Drawing.Size(537, 883);
             this.lvEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvEntities.TabIndex = 2;
             this.lvEntities.UseCompatibleStateImageBehavior = false;
@@ -239,7 +240,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.panel2.Controls.Add(this.label4);
             this.panel2.Controls.Add(this.txtSearch);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel2.Location = new System.Drawing.Point(3, 25);
+            this.panel2.Location = new System.Drawing.Point(3, 22);
             this.panel2.Name = "panel2";
             this.panel2.Size = new System.Drawing.Size(537, 26);
             this.panel2.TabIndex = 1;
@@ -249,7 +250,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(3, 6);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(75, 25);
+            this.label4.Size = new System.Drawing.Size(60, 20);
             this.label4.TabIndex = 1;
             this.label4.Text = "Search";
             // 
@@ -259,7 +260,7 @@ namespace MscrmTools.AttributeUsageInspector
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSearch.Location = new System.Drawing.Point(108, 3);
             this.txtSearch.Name = "txtSearch";
-            this.txtSearch.Size = new System.Drawing.Size(429, 29);
+            this.txtSearch.Size = new System.Drawing.Size(429, 26);
             this.txtSearch.TabIndex = 0;
             this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
             // 
@@ -271,7 +272,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.gbData.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbData.Location = new System.Drawing.Point(0, 0);
             this.gbData.Name = "gbData";
-            this.gbData.Size = new System.Drawing.Size(1084, 929);
+            this.gbData.Size = new System.Drawing.Size(1084, 934);
             this.gbData.TabIndex = 1;
             this.gbData.TabStop = false;
             this.gbData.Text = "Data";
@@ -281,9 +282,9 @@ namespace MscrmTools.AttributeUsageInspector
             this.pnlData.Controls.Add(this.dgvData);
             this.pnlData.Controls.Add(this.pnlFilterInfo);
             this.pnlData.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlData.Location = new System.Drawing.Point(3, 25);
+            this.pnlData.Location = new System.Drawing.Point(3, 22);
             this.pnlData.Name = "pnlData";
-            this.pnlData.Size = new System.Drawing.Size(1078, 881);
+            this.pnlData.Size = new System.Drawing.Size(1078, 889);
             this.pnlData.TabIndex = 7;
             // 
             // dgvData
@@ -301,7 +302,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.dgvData.Name = "dgvData";
             this.dgvData.ReadOnly = true;
             this.dgvData.RowTemplate.Height = 28;
-            this.dgvData.Size = new System.Drawing.Size(1078, 844);
+            this.dgvData.Size = new System.Drawing.Size(1078, 852);
             this.dgvData.TabIndex = 7;
             this.dgvData.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dgvData_ColumnHeaderMouseClick);
             // 
@@ -348,7 +349,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.lblFilterInfo.AutoSize = true;
             this.lblFilterInfo.Location = new System.Drawing.Point(5, 5);
             this.lblFilterInfo.Name = "lblFilterInfo";
-            this.lblFilterInfo.Size = new System.Drawing.Size(856, 25);
+            this.lblFilterInfo.Size = new System.Drawing.Size(704, 20);
             this.lblFilterInfo.TabIndex = 1;
             this.lblFilterInfo.Text = "You can filter attributes displayed by enabling attributes filtering in settings," +
     " then selecting an entity.";
@@ -359,7 +360,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.label5.Dock = System.Windows.Forms.DockStyle.Left;
             this.label5.Location = new System.Drawing.Point(0, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(0, 25);
+            this.label5.Size = new System.Drawing.Size(0, 20);
             this.label5.TabIndex = 0;
             this.label5.Tag = "Statistics based on {0} records";
             // 
@@ -374,9 +375,9 @@ namespace MscrmTools.AttributeUsageInspector
             this.pnlAggregateQueryRecordLimit.Controls.Add(this.label1);
             this.pnlAggregateQueryRecordLimit.Controls.Add(this.lblAggregateQueryRecordLimit);
             this.pnlAggregateQueryRecordLimit.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlAggregateQueryRecordLimit.Location = new System.Drawing.Point(3, 25);
+            this.pnlAggregateQueryRecordLimit.Location = new System.Drawing.Point(3, 22);
             this.pnlAggregateQueryRecordLimit.Name = "pnlAggregateQueryRecordLimit";
-            this.pnlAggregateQueryRecordLimit.Size = new System.Drawing.Size(1078, 881);
+            this.pnlAggregateQueryRecordLimit.Size = new System.Drawing.Size(1078, 889);
             this.pnlAggregateQueryRecordLimit.TabIndex = 2;
             this.pnlAggregateQueryRecordLimit.Visible = false;
             // 
@@ -479,7 +480,7 @@ namespace MscrmTools.AttributeUsageInspector
             // 
             this.panel1.Controls.Add(this.lblCount);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(3, 906);
+            this.panel1.Location = new System.Drawing.Point(3, 911);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(1078, 20);
             this.panel1.TabIndex = 1;
@@ -490,7 +491,7 @@ namespace MscrmTools.AttributeUsageInspector
             this.lblCount.Dock = System.Windows.Forms.DockStyle.Left;
             this.lblCount.Location = new System.Drawing.Point(0, 0);
             this.lblCount.Name = "lblCount";
-            this.lblCount.Size = new System.Drawing.Size(0, 25);
+            this.lblCount.Size = new System.Drawing.Size(0, 20);
             this.lblCount.TabIndex = 0;
             this.lblCount.Tag = "Statistics based on {0} records";
             // 

--- a/MscrmTools.AttributeUsageInspector/PluginControl.resx
+++ b/MscrmTools.AttributeUsageInspector/PluginControl.resx
@@ -124,7 +124,7 @@
   <data name="tsbClose.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAGdYAABnWARjRyu0AAAD5SURBVDhPY0AGRxwM/oMwlIsB8MqDJL4d3gXG2BThlQcJ
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAD5SURBVDhPY0AGRxwM/oMwlIsB8MqDJL4d3gXG2BThlQcJ
         fN294f9TT10wBrGRFRGShyjYvPz/c18jOAbxQeL45KDawcAYJPBl9bz/rwLN4RjExyYG1WwM0YoAYEO+
         Lp7+/02oDVYMksOlGQYghszt//8u0hEFg8QIaQYDkKJv0zr+f4h1Q8EgMagBuAFY88Sm/58TvbFikBxO
         Q0AS33uq/39N9YdjEB+bGIYhIIEf7WX/v2eGwDGIDxLHJwfVDjHgV1Ph/595kWAMYkMVgAIMHLA45OEA
@@ -134,7 +134,7 @@
   <data name="tsbLoadEntities.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAGdYAABnWARjRyu0AAAD2SURBVDhPY6ApyG+c8x/KJA/oe+STb8D9xy//M8j7k29A
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAD2SURBVDhPY6ApyG+c8x/KJA/oe+STb8D9xy//M8j7k29A
         /9xNGAbMX733//7jl4kzVN4qBcUAkItAYkQZALIJrBnJgPr+5WA+sgHxRROxG2YfVoViwPmr9+B8mAFg
         zVB5FIBiOxCDwgIcG1D+5j2n//untCHUIAOYP+GSQAwPTBx8qFYIACccZEkgJtqA9TtPoEpAMVEGgJzO
         rxOJKgHEArpRhA0AaYYFEsj/IZmd/xOKJ/4HRRvISw7h1WAMCxsMA0Ca5SxT/jdPWvk/uWzyf9eYehSN
@@ -144,31 +144,31 @@
   <data name="tsbExportToExcel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAGdYAABnWARjRyu0AAAEVSURBVDhPY0AG6enpISkpKduTk5OfAOk3UGH8IDc3lw+o
-        2AmkITw8/FdaWtofKP0fqgQ/ACr+C1IMxP/QMHEGABX+BOI/8fHxvyMjI7+CMMwAZAxVjgmAkn+A+CYQ
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAEVSURBVDhPY0AG6enpISkpKduTk5OfAOk3UGH8IDc3lw+o
+        2AmkISws7FdaWtofKP0fqgQ/ACr+C1IMxP/QMHEGABX+BOI/8fHxvyMjI7+CMMwAZAxVjgmAkn+A+CYQ
         14BokBjIMJCm1NRUe6DXfEBssGJsAOrfL8AAVAXxgZokYQYgY7BibABkAEgDUOMREB9In4MZkJWVJQHk
         O+I1AKQ4MTHxHZTLAHTyNJJcAFT8GahgARAHAPFbIF8ASH8HaQJFL1QcbyDCbDkKxE+BmtqBNChgiXNB
         UlLSdXQnw9IGVAlhEBoaygwMLFOg7UuBGkFRCrcV2SBkcbwgMzNTFmhgIYiNroFoQ2AApgEbhiohDVBZ
-        MwMDAH8r506s10VWAAAAAElFTkSuQmCC
+        MwMDAEnW5zymHMBBAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsbSettings.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAGdYAABnWARjRyu0AAAMHSURBVDhPdZNbSJNhGMd3Fd1YUZB5FTkSUtQovPGyIgiD
-        wKwMOkBXCaF5nEvd5pzanGl20NGWy8P2be6kzummjqlJNqfmPEQ6tTnDOQ9zmnQT+O9758ws+sHDx/f+
-        n9/7frwPH+Nv2Hlcgb65FYa2dpQ+LUNmFqtFoVBESRrk31QaHYztZshVatTJqbF3FMUMajvk5/OVrQYj
-        trcBbnHJYnx8/PWUR2mJaq0eU9NOrPv8WF5ZhcvlRne3FbV1DQiqDAaXX9xETtjY2IRaqyNBNF0Hq6ur
-        t8YnJuF0zkLf0oZGhQpiyVuIpbWokUj3NhA9e45l7zKGR0YxNjaBnNw8GVmvqHqJefcCTOYudHZ2o/LF
-        KyKd/13FwvJmqawe7oUFWPv64aBl0pzNYoPD41eVCkVwzc9j4OMgbINDEJZX7J1KKBWWYW7OBWOHGdbe
-        95BIZUjPzILH44GySQtuYRG+TDkxNDQCm30YgzY7BCVC8ItLUUJfMoNdUGCR1cnRZbFCq9Mj7lzc1fvJ
-        yc1N8gZ43C7weHyMjjrwYcAGh2Mcqysr8PvWMTMzg3wO108+IpzNLrAIBCVg52Zb6PcDdJ08lfFmNfZJ
-        HdYW3bDbbGiUU3icnoFKURkK8/OQkZpqp/tiyQaEcLrIpZAn41ChqT5JM4sBP1Bk+YpuowFcDgfZGWlU
-        sI9UBOn9h8NcoyLF6ILdB9xpW8Yl7QrOsqXwzs+Cksl+JuqmJSG8DnWwfT9HeR3UTY0zIN9tW0KC1oNo
-        8WdEsaRrBqXUy+2Ygn0LuKGZwbHCdmVQ2yGU3665UPsJQ+sAq9+HBM0iYsWTOJ5DGek4JiRLob3Y5MWt
-        Vi9GvgNJikkQZ8emiazoxdgmcM/opWUPYuiTj+SozHR0iuShHJ0pWjyOy6pF3DYsYfwHQBySBYis6MPD
-        Lh+u6ZcQXePYJwdhhubIzVGvR3FF7cED0xrO0E4wYzDCWFRPhKgXzDIrTrCVZJx/yruEh+VSlnBRD06X
-        94I4wfUA5NfcHVFgnP9hd+R0MZi/AA/R8b24AHzGAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAMHSURBVDhPdZNbSJNhGMd3Fd1YUZB5FSkJKWoU3nhZEYRB
+        YFYGHaCrhNA8zuXc5tTZnGl20NGWy8P2be6kzummjqlJNqfmPEQ6tTnDOQ9zmnQT+O9758ws+sHDx/f+
+        n9/7frwPH+NvWPncYn1zKwxt7Sh9WoasbGaLQqGIljTIv6k0OhjbzZCr1KiTU2PvKCoiqO3AZvOVrQYj
+        trcBbolgMSEh4Xrqo/QktVaPqWkn1n1+LK+swuVyo7vbitq6BgRVBoPLL2kiJ2xsbEKt1ZEghq6D1dXV
+        W+MTk3A6Z6FvaUOjQgWx5C3E0lrUSKR7G4iePceydxnDI6MYG5tAbl6+jKxXVL3EvHsBJnMXOju7Ufni
+        FZHO/64SYXmzVFYP98ICrH39cNAyac5hssDh8atKhSK45ucx8HEQtsEhCMsr9k4llArLMDfngrHDDGvv
+        e0ikMmRkZcPj8UDZpAW3sAhfppwYGhqBzT6MQZsdxQIh+CWlENCXzGAVFFhkdXJ0WazQ6vSIPxd/9X5K
+        SnOTvAEetws8Hh+jow58GLDB4RjH6soK/L51zMzMgM3h+slHhLNYBZbiYgFYeTkW+v0AXSdPZb5ZjXtS
+        h7VFN+w2GxrlFB5nZKJSVIZCdj4y09LsdF8c2YAQThe5FPJkHCo01SdrZjHgB4osX9FtNIDL4SAnM50K
+        9pGKJL3/cJhrVKQaXbD7gDtty7ikXcFZlhTe+VkoZLKfSbppSQivQx1s389RXgd1U+MMyHfblpCo9SBG
+        /BnRTOmaQSn1cjumYN8CbmhmcKywXRnUdgjlt2su1H7C0DrA7PchUbOIOPEkjudSRjqODclWaC82eXGr
+        1YuR70CyYhLE2bFpoip6MbYJ3DN6admDWPrkI7kqMx2dInkoR2eKEY/jsmoRtw1LGP8BEIdkAaIq+vCw
+        y4dr+iXE1Dj2yUEiQnPl5ujXo7ii9uCBaQ1naCeYMRhhTKonUtSLiDIrTrCUZJx/yruEh+VRlnBRD06X
+        94I4wfUA5NfcHVFgnP9hd+R0MSJ+AQ438bw30P9rAAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="clDisplayName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/MscrmTools.AttributeUsageInspector/Settings.cs
+++ b/MscrmTools.AttributeUsageInspector/Settings.cs
@@ -19,6 +19,10 @@ namespace MscrmTools.AttributeUsageInspector
         [XmlIgnore]
         public IDictionary<string, EntityFilterSetting> Filters { get; } = new Dictionary<string, EntityFilterSetting>();
 
+        public bool UseFetchXMLQuery { get; set; }
+        [XmlIgnore]
+        public string FetchXMLQuery = string.Empty;
+
         public string SQLConnectionString = string.Empty;
         internal bool UseSQLQuery = false;
         internal int SQLCommandTimeout;

--- a/MscrmTools.AttributeUsageInspector/SettingsDialog.Designer.cs
+++ b/MscrmTools.AttributeUsageInspector/SettingsDialog.Designer.cs
@@ -43,6 +43,7 @@
             this.tbSQLConnectionString = new System.Windows.Forms.TextBox();
             this.nudCommandTimeOut = new System.Windows.Forms.NumericUpDown();
             this.lblCommandTimeout = new System.Windows.Forms.Label();
+            this.chkUseFetchXMLQuery = new System.Windows.Forms.CheckBox();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNumberOfRecordsPerCall)).BeginInit();
@@ -56,19 +57,17 @@
             this.panel1.Controls.Add(this.lblHeader);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(765, 72);
+            this.panel1.Size = new System.Drawing.Size(626, 60);
             this.panel1.TabIndex = 0;
             // 
             // lblHeader
             // 
             this.lblHeader.AutoSize = true;
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Light", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeader.Location = new System.Drawing.Point(4, 11);
-            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblHeader.Location = new System.Drawing.Point(3, 9);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(129, 45);
+            this.lblHeader.Size = new System.Drawing.Size(109, 38);
             this.lblHeader.TabIndex = 0;
             this.lblHeader.Text = "Settings";
             // 
@@ -79,19 +78,18 @@
             this.panel2.Controls.Add(this.btnOK);
             this.panel2.Controls.Add(this.btnCancel);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel2.Location = new System.Drawing.Point(0, 449);
-            this.panel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panel2.Location = new System.Drawing.Point(0, 543);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(765, 72);
+            this.panel2.Size = new System.Drawing.Size(626, 60);
             this.panel2.TabIndex = 1;
             // 
             // btnTestConnection
             // 
             this.btnTestConnection.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnTestConnection.Location = new System.Drawing.Point(20, 13);
-            this.btnTestConnection.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnTestConnection.Location = new System.Drawing.Point(16, 11);
+            this.btnTestConnection.Margin = new System.Windows.Forms.Padding(5);
             this.btnTestConnection.Name = "btnTestConnection";
-            this.btnTestConnection.Size = new System.Drawing.Size(200, 42);
+            this.btnTestConnection.Size = new System.Drawing.Size(164, 35);
             this.btnTestConnection.TabIndex = 6;
             this.btnTestConnection.Text = "Test Connection";
             this.btnTestConnection.UseVisualStyleBackColor = true;
@@ -101,10 +99,10 @@
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.Location = new System.Drawing.Point(464, 13);
-            this.btnOK.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnOK.Location = new System.Drawing.Point(380, 11);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(5);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(138, 42);
+            this.btnOK.Size = new System.Drawing.Size(113, 35);
             this.btnOK.TabIndex = 5;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -113,10 +111,10 @@
             // btnCancel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCancel.Location = new System.Drawing.Point(611, 13);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnCancel.Location = new System.Drawing.Point(500, 11);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(5);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(138, 42);
+            this.btnCancel.Size = new System.Drawing.Size(113, 35);
             this.btnCancel.TabIndex = 4;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -125,10 +123,9 @@
             // lblNbrOfRecordsPerCall
             // 
             this.lblNbrOfRecordsPerCall.AutoSize = true;
-            this.lblNbrOfRecordsPerCall.Location = new System.Drawing.Point(15, 87);
-            this.lblNbrOfRecordsPerCall.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblNbrOfRecordsPerCall.Location = new System.Drawing.Point(12, 72);
             this.lblNbrOfRecordsPerCall.Name = "lblNbrOfRecordsPerCall";
-            this.lblNbrOfRecordsPerCall.Size = new System.Drawing.Size(239, 25);
+            this.lblNbrOfRecordsPerCall.Size = new System.Drawing.Size(194, 20);
             this.lblNbrOfRecordsPerCall.TabIndex = 2;
             this.lblNbrOfRecordsPerCall.Text = "Number of records per call";
             // 
@@ -141,8 +138,7 @@
             0,
             0,
             0});
-            this.nudNumberOfRecordsPerCall.Location = new System.Drawing.Point(295, 83);
-            this.nudNumberOfRecordsPerCall.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.nudNumberOfRecordsPerCall.Location = new System.Drawing.Point(241, 69);
             this.nudNumberOfRecordsPerCall.Maximum = new decimal(new int[] {
             5000,
             0,
@@ -154,7 +150,7 @@
             0,
             0});
             this.nudNumberOfRecordsPerCall.Name = "nudNumberOfRecordsPerCall";
-            this.nudNumberOfRecordsPerCall.Size = new System.Drawing.Size(453, 29);
+            this.nudNumberOfRecordsPerCall.Size = new System.Drawing.Size(371, 26);
             this.nudNumberOfRecordsPerCall.TabIndex = 3;
             this.nudNumberOfRecordsPerCall.Value = new decimal(new int[] {
             10,
@@ -165,10 +161,9 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(15, 142);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(12, 118);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(253, 25);
+            this.label1.Size = new System.Drawing.Size(208, 20);
             this.label1.TabIndex = 4;
             this.label1.Text = "Number of attributes per call";
             // 
@@ -181,8 +176,7 @@
             0,
             0,
             0});
-            this.nudNumberOfAttributesPerCall.Location = new System.Drawing.Point(295, 138);
-            this.nudNumberOfAttributesPerCall.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.nudNumberOfAttributesPerCall.Location = new System.Drawing.Point(241, 115);
             this.nudNumberOfAttributesPerCall.Maximum = new decimal(new int[] {
             5000,
             0,
@@ -194,7 +188,7 @@
             0,
             0});
             this.nudNumberOfAttributesPerCall.Name = "nudNumberOfAttributesPerCall";
-            this.nudNumberOfAttributesPerCall.Size = new System.Drawing.Size(453, 29);
+            this.nudNumberOfAttributesPerCall.Size = new System.Drawing.Size(371, 26);
             this.nudNumberOfAttributesPerCall.TabIndex = 5;
             this.nudNumberOfAttributesPerCall.Value = new decimal(new int[] {
             50,
@@ -205,21 +199,22 @@
             // chkFilterAttributes
             // 
             this.chkFilterAttributes.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkFilterAttributes.Location = new System.Drawing.Point(13, 185);
-            this.chkFilterAttributes.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.chkFilterAttributes.Location = new System.Drawing.Point(11, 154);
+            this.chkFilterAttributes.Margin = new System.Windows.Forms.Padding(5);
             this.chkFilterAttributes.Name = "chkFilterAttributes";
-            this.chkFilterAttributes.Size = new System.Drawing.Size(308, 44);
+            this.chkFilterAttributes.Size = new System.Drawing.Size(252, 37);
             this.chkFilterAttributes.TabIndex = 6;
             this.chkFilterAttributes.Text = "Filter attributes";
             this.chkFilterAttributes.UseVisualStyleBackColor = true;
+            this.chkFilterAttributes.CheckedChanged += new System.EventHandler(this.chkFilterAttributes_CheckedChanged);
             // 
             // chkUseSQL
             // 
             this.chkUseSQL.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.chkUseSQL.Location = new System.Drawing.Point(13, 236);
-            this.chkUseSQL.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.chkUseSQL.Location = new System.Drawing.Point(11, 197);
+            this.chkUseSQL.Margin = new System.Windows.Forms.Padding(5);
             this.chkUseSQL.Name = "chkUseSQL";
-            this.chkUseSQL.Size = new System.Drawing.Size(308, 44);
+            this.chkUseSQL.Size = new System.Drawing.Size(252, 37);
             this.chkUseSQL.TabIndex = 7;
             this.chkUseSQL.Text = "Use Direct SQL Query";
             this.chkUseSQL.UseVisualStyleBackColor = true;
@@ -228,11 +223,11 @@
             // tbSQLConnectionString
             // 
             this.tbSQLConnectionString.Enabled = false;
-            this.tbSQLConnectionString.Location = new System.Drawing.Point(20, 295);
-            this.tbSQLConnectionString.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tbSQLConnectionString.Location = new System.Drawing.Point(16, 246);
+            this.tbSQLConnectionString.Margin = new System.Windows.Forms.Padding(5);
             this.tbSQLConnectionString.Multiline = true;
             this.tbSQLConnectionString.Name = "tbSQLConnectionString";
-            this.tbSQLConnectionString.Size = new System.Drawing.Size(725, 141);
+            this.tbSQLConnectionString.Size = new System.Drawing.Size(594, 118);
             this.tbSQLConnectionString.TabIndex = 8;
             this.tbSQLConnectionString.Text = "Data Source=;Initial Catalog=;Integrated Security=SSPI";
             // 
@@ -245,8 +240,7 @@
             0,
             0,
             0});
-            this.nudCommandTimeOut.Location = new System.Drawing.Point(546, 240);
-            this.nudCommandTimeOut.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.nudCommandTimeOut.Location = new System.Drawing.Point(447, 200);
             this.nudCommandTimeOut.Maximum = new decimal(new int[] {
             5000,
             0,
@@ -258,7 +252,7 @@
             0,
             0});
             this.nudCommandTimeOut.Name = "nudCommandTimeOut";
-            this.nudCommandTimeOut.Size = new System.Drawing.Size(202, 29);
+            this.nudCommandTimeOut.Size = new System.Drawing.Size(165, 26);
             this.nudCommandTimeOut.TabIndex = 9;
             this.nudCommandTimeOut.Value = new decimal(new int[] {
             120,
@@ -269,18 +263,30 @@
             // lblCommandTimeout
             // 
             this.lblCommandTimeout.AutoSize = true;
-            this.lblCommandTimeout.Location = new System.Drawing.Point(354, 247);
-            this.lblCommandTimeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblCommandTimeout.Location = new System.Drawing.Point(290, 206);
             this.lblCommandTimeout.Name = "lblCommandTimeout";
-            this.lblCommandTimeout.Size = new System.Drawing.Size(184, 25);
+            this.lblCommandTimeout.Size = new System.Drawing.Size(146, 20);
             this.lblCommandTimeout.TabIndex = 10;
             this.lblCommandTimeout.Text = "Command TimeOut";
             // 
+            // chkUseFetchXMLQuery
+            // 
+            this.chkUseFetchXMLQuery.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.chkUseFetchXMLQuery.Location = new System.Drawing.Point(16, 374);
+            this.chkUseFetchXMLQuery.Margin = new System.Windows.Forms.Padding(5);
+            this.chkUseFetchXMLQuery.Name = "chkUseFetchXMLQuery";
+            this.chkUseFetchXMLQuery.Size = new System.Drawing.Size(252, 37);
+            this.chkUseFetchXMLQuery.TabIndex = 11;
+            this.chkUseFetchXMLQuery.Text = "Use FetchXML query";
+            this.chkUseFetchXMLQuery.UseVisualStyleBackColor = true;
+            this.chkUseFetchXMLQuery.CheckedChanged += new System.EventHandler(this.chkUseFetchXMLQuery_CheckedChanged);
+            // 
             // SettingsDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(765, 521);
+            this.ClientSize = new System.Drawing.Size(626, 603);
+            this.Controls.Add(this.chkUseFetchXMLQuery);
             this.Controls.Add(this.lblCommandTimeout);
             this.Controls.Add(this.nudCommandTimeOut);
             this.Controls.Add(this.tbSQLConnectionString);
@@ -293,7 +299,6 @@
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "SettingsDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.panel1.ResumeLayout(false);
@@ -324,5 +329,6 @@
         private System.Windows.Forms.Button btnTestConnection;
         private System.Windows.Forms.NumericUpDown nudCommandTimeOut;
         private System.Windows.Forms.Label lblCommandTimeout;
+        private System.Windows.Forms.CheckBox chkUseFetchXMLQuery;
     }
 }

--- a/MscrmTools.AttributeUsageInspector/SettingsDialog.cs
+++ b/MscrmTools.AttributeUsageInspector/SettingsDialog.cs
@@ -25,11 +25,13 @@ namespace MscrmTools.AttributeUsageInspector
             chkFilterAttributes.Checked = settings.FilterAttributes;
 
             chkUseSQL.Checked = settings.UseSQLQuery;
+            chkUseFetchXMLQuery.Checked = settings.UseFetchXMLQuery;
 
             tbSQLConnectionString.Text = settings.SQLConnectionString;
             btnTestConnection.Visible = chkUseSQL.Checked;
             lblCommandTimeout.Enabled = chkUseSQL.Checked;
             nudCommandTimeOut.Enabled = chkUseSQL.Checked;
+
         }
 
         public Settings Settings { get; }
@@ -70,6 +72,7 @@ namespace MscrmTools.AttributeUsageInspector
             Settings.UseSQLQuery = chkUseSQL.Checked;
             Settings.SQLConnectionString = tbSQLConnectionString.Text;
             Settings.SQLCommandTimeout = Convert.ToInt32(nudCommandTimeOut.Value);
+            Settings.UseFetchXMLQuery = chkUseFetchXMLQuery.Checked;
             DialogResult = DialogResult.OK;
             Close();
         }
@@ -85,6 +88,46 @@ namespace MscrmTools.AttributeUsageInspector
             btnTestConnection.Visible = chkUseSQL.Checked;
             lblCommandTimeout.Enabled = chkUseSQL.Checked;
             nudCommandTimeOut.Enabled = chkUseSQL.Checked;
+            if (chkUseSQL.Checked)
+            {
+                chkUseFetchXMLQuery.Checked = false;
+                chkUseFetchXMLQuery.Enabled = false;
+            }
+            else
+            {
+                chkUseFetchXMLQuery.Enabled = true;
+            }
+        }
+
+        private void chkUseFetchXMLQuery_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkUseFetchXMLQuery.Checked)
+            {
+                chkUseSQL.Checked = false;
+                chkUseSQL.Enabled = false;
+                chkFilterAttributes.Checked = false;
+                chkFilterAttributes.Enabled = false;
+                nudNumberOfAttributesPerCall.Enabled = false;
+            }
+            else
+            {
+                chkUseSQL.Enabled = true;
+                chkFilterAttributes.Enabled = true;
+                nudNumberOfAttributesPerCall.Enabled = true;
+            }
+        }
+
+        private void chkFilterAttributes_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkFilterAttributes.Checked)
+            {
+                chkUseFetchXMLQuery.Checked = false;
+                chkUseFetchXMLQuery.Enabled = false;
+            }
+            else
+            {
+                chkUseFetchXMLQuery.Enabled = true;
+            }
         }
     }
 }

--- a/MscrmTools.AttributeUsageInspector/app.config
+++ b/MscrmTools.AttributeUsageInspector/app.config
@@ -18,6 +18,14 @@
         <assemblyIdentity name="McTools.Xrm.Connection.WinForms" publicKeyToken="f1559f79cf894e27" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2017.1.9" newVersion="1.2017.1.9" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/MscrmTools.AttributeUsageInspector/packages.config
+++ b/MscrmTools.AttributeUsageInspector/packages.config
@@ -1,16 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DockPanelSuite" version="3.0.4" targetFramework="net462" />
+  <package id="DockPanelSuite.ThemeVS2015" version="3.0.4" targetFramework="net462" />
   <package id="EPPlus" version="4.1.0" targetFramework="net452" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.3" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.3" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.3" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.3" targetFramework="net462" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.29.0" targetFramework="net462" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
-  <package id="MscrmTools.Xrm.Connection" version="1.2017.10.15" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Core" version="2.12.0" targetFramework="net452" />
-  <package id="XrmToolBoxPackage" version="1.2017.10.19" targetFramework="net462" />
+  <package id="MscrmTools.Xrm.Connection" version="1.2018.7.19" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
+  <package id="NuGet.Core" version="2.14.0" targetFramework="net462" />
+  <package id="XrmToolBoxPackage" version="1.2018.7.28" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
I have extended this utility to allow users to filter the data using a **FetchXML** query. This new feature shouldn't clash with the previous existing functionality (e.g. attribute filters or SQL queries).

The business reason behind this extension is to be able to understand the attribute utilisation for a particular subset of information. For instance, over all the contacts in the system, we need to analyse the attribute utilisation just for those business contacts.

The FetchXML can be generated based on a system or user view for the selected entity or a customer FetchXML query provided by the user.

The Settings dialog has been adapted to select this new FetchXML option. 